### PR TITLE
fix: change PositionSpec.Height field type 

### DIFF
--- a/marketing/v12/adcreative.go
+++ b/marketing/v12/adcreative.go
@@ -317,7 +317,7 @@ type PositionSpec struct {
 	X        float64 `json:"x"`
 	Y        float64 `json:"y"`
 	Width    float64 `json:"width"`
-	Height   int     `json:"height"`
+	Height   float64 `json:"height"`
 	Rotation int     `json:"rotation"`
 }
 


### PR DESCRIPTION
update type of height field in PositionSpec struct from int to float, height and width are represented as fractions in the facebook API