### PR TITLE
Add ContextualMultiAds field to AdCreative

### DIFF
--- a/marketing/v24/adcreative.go
+++ b/marketing/v24/adcreative.go
@@ -271,6 +271,9 @@ type AdCreative struct {
 	Adlabels []json.RawMessage `json:"adlabels,omitempty"`
 	// DegreesOfFreedomSpec Specifies the types of transformations that are enabled for the given creative. For more information, see Ad Creative Degrees Of Freedom Spec, Reference.
 	DegreesOfFreedomSpec *DegreesOfFreedomSpec `json:"degrees_of_freedom_spec,omitempty"`
+	// ContextualMultiAds controls whether the ad can appear in multi-advertiser ad units.
+	// See https://developers.facebook.com/docs/marketing-api/creative/multi-advertiser-ads/
+	ContextualMultiAds *EnrollStatus `json:"contextual_multi_ads,omitempty"`
 	// AssetFeedSpec for dynamic creative or placement-specific asset customization
 	AssetFeedSpec *AssetFeedSpec `json:"asset_feed_spec,omitempty"`
 	// DestinationSpec for website destination optimization (v24.0+)


### PR DESCRIPTION
## Summary
- Adds `ContextualMultiAds *EnrollStatus` field to the `AdCreative` struct (v24)
- Allows opting out of multi-advertiser ad units via `contextual_multi_ads: { enroll_status: "OPT_OUT" }`
- See [Meta docs](https://developers.facebook.com/docs/marketing-api/creative/multi-advertiser-ads/)