### PR TITLE
chore: upgrade GitHub Actions to Node.js 24 (deadline Jun 16)

### DIFF
--- a/.github/workflows/auto-versioning.yml
+++ b/.github/workflows/auto-versioning.yml
@@ -36,7 +36,7 @@ jobs:
           echo "::set-output name=new_tag::$new_tag"
 
       - name: Prepare Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ steps.bump_version.outputs.new_tag }}
           name: Release ${{ steps.bump_version.outputs.new_tag }}


### PR DESCRIPTION
## Summary

GitHub will force Node.js 24 as the default Actions runtime on **June 16, 2026**. Actions still on Node.js 20 will fail after that date.

This PR upgrades the affected actions in this repo to Node.js 24-compatible versions. See the diff for exact changes.

_Ref: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/_