### PR TITLE
chore: upgrade GitHub Actions to Node.js 24 (deadline Jun 16)

### DIFF
--- a/.github/workflows/auto-versioning.yml
+++ b/.github/workflows/auto-versioning.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 


### PR DESCRIPTION
## Summary

GitHub will break all Actions still on Node.js 20 on **June 16, 2026**. This PR upgrades the affected actions in this repo to Node.js 24-compatible versions.

_Ref: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/_