### PR TITLE
Add EducationSchools to v24 FlexibleSpec

### DIFF
--- a/marketing/v24/adset.go
+++ b/marketing/v24/adset.go
@@ -300,6 +300,7 @@ type FlexibleSpec struct {
 	WorkPositions        []IDContainer `json:"work_positions,omitempty"`
 	Politics             []IDContainer `json:"politics,omitempty"`
 	EducationMajors      []IDContainer `json:"education_majors,omitempty"`
+	EducationSchools     []IDContainer `json:"education_schools,omitempty"`
 	EducationStatuses    []int         `json:"education_statuses,omitempty"`
 	RelationshipStatuses []int         `json:"relationship_statuses,omitempty"`
 }


### PR DESCRIPTION
Adds `EducationSchools []IDContainer` to the v24 `FlexibleSpec` so callers can target Meta's `education_schools` demographic (specific schools/universities, returned by `targetingsearch` with string IDs).

Needed by jw-business-api to support school targeting in the `search_supplier` endpoint and adset generation.

Once merged, a v1.51.0 tag is needed for the consumer bump.