### PR TITLE
Classify link-media attachments as link posts instead of status

### DIFF
--- a/marketing/v24/post.go
+++ b/marketing/v24/post.go
@@ -103,11 +103,7 @@ func (ps *PostService) getPostAttachments(ctx context.Context, post *Post) error
 	sat := strings.TrimSpace(pA.StoryAttachmentType)
 	mt := strings.TrimSpace(pA.MediaType)
 	if mt != "" {
-		if mt == "link" {
-			post.Type = "status"
-		} else {
-			post.Type = mt
-		}
+		post.Type = mt
 	} else if sat != "" {
 		post.Type = sat
 	}


### PR DESCRIPTION
media_type=="link" was mapped to "status", which is not a valid post type and gets clamped to "unknown" by the caller. Map it to "link" (the actual type) so external-link/share posts (e.g. Prime Video store links) classify correctly and can be uploaded via LinkData.