### PR TITLE
Add age_range targeting field for Advantage+ audience age suggestions

### DIFF
--- a/marketing/v24/adset.go
+++ b/marketing/v24/adset.go
@@ -245,9 +245,12 @@ type Targeting struct {
 	AudienceNetworkPositions []string `json:"audience_network_positions,omitempty"`
 	MessengerPositions       []string `json:"messenger_positions,omitempty"`
 
-	AgeMin  uint64 `json:"age_min,omitempty"`
-	AgeMax  uint64 `json:"age_max,omitempty"`
-	Genders []int  `json:"genders,omitempty"`
+	AgeMin uint64 `json:"age_min,omitempty"`
+	AgeMax uint64 `json:"age_max,omitempty"`
+	// AgeRange is the [min, max] age suggestion used with Advantage+ audience;
+	// unlike age_min/age_max it is not a hard constraint (v23.0+).
+	AgeRange []uint64 `json:"age_range,omitempty"`
+	Genders  []int    `json:"genders,omitempty"`
 
 	AppInstallState string `json:"app_install_state,omitempty"`
 


### PR DESCRIPTION
Adds the `targeting.age_range` field (`[min, max]`, v23.0+) to the v24 `Targeting` struct.

With Advantage+ audience enabled, Meta only accepts `age_min` 18–25 and `age_max` 65 as hard constraints — narrower ranges are rejected with "You can add a higher/lower minimum/maximum age as a suggestion instead". The sanctioned path is passing the range as a suggestion via `age_range`.

Needed by jw-business-api (justwatch/jw-business-api#4395), which currently pins this branch as a pseudo-version and will re-pin once this is merged and tagged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)