### PR TITLE
Add batched Facebook comment counts

### DIFF
--- a/marketing/v24/post.go
+++ b/marketing/v24/post.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/url"
+	"sort"
 	"strings"
 
 	"golang.org/x/sync/errgroup"
@@ -159,6 +161,86 @@ func (ps *PostService) CountComments(ctx context.Context, postID string) (uint64
 	err := ps.c.GetJSON(ctx, fb.NewRoute(Version, "/%s/comments", postID).Limit(0).Summary("1").String(), sc)
 
 	return sc.Summary.TotalCount, err
+}
+
+// CountCommentsByPostIDs returns comment counts keyed by post ID.
+// Attached objects are resolved when the post itself reports no comments.
+func (ps *PostService) CountCommentsByPostIDs(ctx context.Context, postIDs []string) (map[string]uint64, error) {
+	const batchSize = 50
+
+	counts := make(map[string]uint64, len(postIDs))
+	postIDsByObjectID := map[string][]string{}
+
+	for start := 0; start < len(postIDs); start += batchSize {
+		end := start + batchSize
+		if end > len(postIDs) {
+			end = len(postIDs)
+		}
+
+		posts, err := ps.fetchPostCommentSummaries(ctx, postIDs[start:end])
+		if err != nil {
+			return nil, err
+		}
+		for postID, post := range posts {
+			if post.Comments.Summary.TotalCount > 0 || post.ObjectID == "" {
+				counts[postID] = post.Comments.Summary.TotalCount
+				continue
+			}
+			postIDsByObjectID[post.ObjectID] = append(postIDsByObjectID[post.ObjectID], postID)
+		}
+	}
+
+	objectIDs := make([]string, 0, len(postIDsByObjectID))
+	for objectID := range postIDsByObjectID {
+		objectIDs = append(objectIDs, objectID)
+	}
+	sort.Strings(objectIDs)
+
+	for start := 0; start < len(objectIDs); start += batchSize {
+		end := start + batchSize
+		if end > len(objectIDs) {
+			end = len(objectIDs)
+		}
+
+		objects, err := ps.fetchPostCommentSummaries(ctx, objectIDs[start:end])
+		if err != nil {
+			return nil, err
+		}
+		for objectID, object := range objects {
+			for _, postID := range postIDsByObjectID[objectID] {
+				counts[postID] = object.Comments.Summary.TotalCount
+			}
+		}
+	}
+
+	return counts, nil
+}
+
+type postCommentSummary struct {
+	ObjectID string `json:"object_id"`
+	Comments struct {
+		Summary struct {
+			TotalCount uint64 `json:"total_count"`
+		} `json:"summary"`
+	} `json:"comments"`
+}
+
+func (ps *PostService) fetchPostCommentSummaries(ctx context.Context, postIDs []string) (map[string]postCommentSummary, error) {
+	route := fb.NewRoute(Version, "/").
+		Fields("object_id", "comments.limit(0).summary(true)")
+	requestURL, err := url.Parse(route.String())
+	if err != nil {
+		return nil, err
+	}
+	query := requestURL.Query()
+	query.Set("ids", strings.Join(postIDs, ","))
+	requestURL.RawQuery = query.Encode()
+
+	posts := map[string]postCommentSummary{}
+	if err := ps.c.GetJSON(ctx, requestURL.String(), &posts); err != nil {
+		return nil, err
+	}
+	return posts, nil
 }
 
 // ListComments creates a new CommentListCall

--- a/marketing/v24/post_comments_test.go
+++ b/marketing/v24/post_comments_test.go
@@ -1,0 +1,101 @@
+package v24
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/go-kit/log"
+	"github.com/justwatch/facebook-marketing-api-golang-sdk/fb"
+)
+
+func TestCountCommentsByPostIDsBatchesAndResolvesAttachedObjects(t *testing.T) {
+	postIDs := make([]string, 51)
+	for i := range postIDs {
+		postIDs[i] = fmt.Sprintf("post-%d", i)
+	}
+	postIDs[0] = "page_shell"
+
+	requests := 0
+	client := fb.NewClient(log.NewNopLogger(), "token", "")
+	client.Client = &http.Client{Transport: postCommentsRoundTripFunc(func(request *http.Request) (*http.Response, error) {
+		requests++
+		if request.URL.Path != "/v24.0/" {
+			t.Fatalf("request path = %q, want %q", request.URL.Path, "/v24.0/")
+		}
+		if got, want := request.URL.Query().Get("fields"), "object_id,comments.limit(0).summary(true)"; got != want {
+			t.Fatalf("fields = %q, want %q", got, want)
+		}
+
+		var body string
+		switch request.URL.Query().Get("ids") {
+		case strings.Join(postIDs[:50], ","):
+			body = `{
+				"page_shell": {
+					"object_id": "reel",
+					"comments": {"summary": {"total_count": 0}}
+				},
+				"post-1": {
+					"comments": {"summary": {"total_count": 2}}
+				},
+				"post-2": {
+					"comments": {"summary": {"total_count": 0}}
+				}
+			}`
+		case postIDs[50]:
+			body = `{
+				"post-50": {
+					"comments": {"summary": {"total_count": 4}}
+				}
+			}`
+		case "reel":
+			body = `{
+				"reel": {
+					"comments": {"summary": {"total_count": 3}}
+				}
+			}`
+		default:
+			t.Fatalf("unexpected ids query: %q", request.URL.Query().Get("ids"))
+		}
+
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Status:     "200 OK",
+			Body:       io.NopCloser(strings.NewReader(body)),
+			Request:    request,
+		}, nil
+	})}
+	service := &PostService{c: client}
+
+	got, err := service.CountCommentsByPostIDs(context.Background(), postIDs)
+	if err != nil {
+		t.Fatalf("CountCommentsByPostIDs() error = %v", err)
+	}
+	if requests != 3 {
+		t.Fatalf("requests = %d, want 3", requests)
+	}
+
+	want := map[string]uint64{
+		"page_shell": 3,
+		"post-1":     2,
+		"post-2":     0,
+		"post-50":    4,
+	}
+	for postID, wantCount := range want {
+		if count, ok := got[postID]; !ok || count != wantCount {
+			t.Fatalf("count for %s = %d, %t; want %d, true", postID, count, ok, wantCount)
+		}
+	}
+	if _, ok := got["post-3"]; ok {
+		t.Fatal("missing API response for post-3 should not produce a count")
+	}
+}
+
+type postCommentsRoundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f postCommentsRoundTripFunc) RoundTrip(request *http.Request) (*http.Response, error) {
+	return f(request)
+}


### PR DESCRIPTION
## Summary
- fetch Facebook comment counts in batches of 50 post IDs
- resolve attached-object comment counts in additional batches
- preserve missing API responses for callers to handle

## Test plan
- [x] `go test ./marketing/v24 -run TestCountCommentsByPostIDsBatchesAndResolvesAttachedObjects`
- [ ] `go test ./...` (existing campaign route tests fail on `origin/main` in `marketing/v22` and `marketing/v24`)