### PR TITLE
Fix batched social Graph requests

### DIFF
--- a/marketing/v24/batch.go
+++ b/marketing/v24/batch.go
@@ -1,0 +1,129 @@
+package v24
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/justwatch/facebook-marketing-api-golang-sdk/fb"
+	"golang.org/x/sync/errgroup"
+)
+
+type graphBatchRequest struct {
+	Method      string `json:"method"`
+	RelativeURL string `json:"relative_url"`
+}
+
+type graphBatchResponse struct {
+	Code int    `json:"code"`
+	Body string `json:"body"`
+}
+
+func (ps *PostService) getBatch(ctx context.Context, relativeURLs []string) ([]graphBatchResponse, error) {
+	batch := make([]graphBatchRequest, len(relativeURLs))
+	for i, relativeURL := range relativeURLs {
+		batch[i] = graphBatchRequest{
+			Method:      http.MethodGet,
+			RelativeURL: relativeURL,
+		}
+	}
+	batchJSON, err := json.Marshal(batch)
+	if err != nil {
+		return nil, err
+	}
+
+	form := url.Values{"batch": {string(batchJSON)}}
+	request, err := http.NewRequestWithContext(
+		ctx,
+		http.MethodPost,
+		fb.NewRoute(Version, "/").String(),
+		strings.NewReader(form.Encode()),
+	)
+	if err != nil {
+		return nil, err
+	}
+	request.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	response, err := ps.c.Do(request)
+	if err != nil {
+		return nil, err
+	}
+	defer response.Body.Close()
+
+	body, err := io.ReadAll(response.Body)
+	if err != nil {
+		return nil, err
+	}
+	if response.StatusCode != http.StatusOK {
+		if graphErr := graphError(body); graphErr != nil {
+			return nil, graphErr
+		}
+		return nil, fmt.Errorf("unexpected status %s", response.Status)
+	}
+
+	batchResponses := []graphBatchResponse{}
+	if err := json.Unmarshal(body, &batchResponses); err != nil {
+		return nil, err
+	}
+	if len(batchResponses) != len(relativeURLs) {
+		return nil, fmt.Errorf("received %d Facebook batch responses for %d requests", len(batchResponses), len(relativeURLs))
+	}
+	return batchResponses, nil
+}
+
+func (ps *PostService) getBatches(ctx context.Context, relativeURLs []string, batchSize, concurrency int) ([]graphBatchResponse, error) {
+	responses := make([]graphBatchResponse, len(relativeURLs))
+	group, groupCtx := errgroup.WithContext(ctx)
+	semaphore := make(chan struct{}, concurrency)
+
+	for start := 0; start < len(relativeURLs); start += batchSize {
+		end := start + batchSize
+		if end > len(relativeURLs) {
+			end = len(relativeURLs)
+		}
+
+		batchStart := start
+		batchURLs := append([]string(nil), relativeURLs[start:end]...)
+		group.Go(func() error {
+			select {
+			case semaphore <- struct{}{}:
+				defer func() { <-semaphore }()
+			case <-groupCtx.Done():
+				return groupCtx.Err()
+			}
+
+			batchResponses, err := ps.getBatch(groupCtx, batchURLs)
+			if err != nil {
+				return err
+			}
+			copy(responses[batchStart:batchStart+len(batchResponses)], batchResponses)
+			return nil
+		})
+	}
+	if err := group.Wait(); err != nil {
+		return nil, err
+	}
+	return responses, nil
+}
+
+func decodeGraphBatchResponse(response graphBatchResponse, target interface{}) error {
+	if response.Code != http.StatusOK {
+		if graphErr := graphError([]byte(response.Body)); graphErr != nil {
+			return graphErr
+		}
+		return fmt.Errorf("unexpected Facebook batch status %d", response.Code)
+	}
+	return json.Unmarshal([]byte(response.Body), target)
+}
+
+func graphError(body []byte) error {
+	container := fb.ErrorContainer{}
+	if err := json.Unmarshal(body, &container); err != nil {
+		return nil
+	}
+	return container.GetError()
+}

--- a/marketing/v24/instagram_post.go
+++ b/marketing/v24/instagram_post.go
@@ -3,7 +3,6 @@ package v24
 import (
 	"context"
 	"net/url"
-	"strings"
 
 	"github.com/justwatch/facebook-marketing-api-golang-sdk/fb"
 )
@@ -87,6 +86,36 @@ func (ps *PostService) GetInstagramPost(ctx context.Context, postID string) (*In
 	return &res, nil
 }
 
+// GetInstagramPermalinksByMediaIDs returns permalinks keyed by media ID.
+func (ps *PostService) GetInstagramPermalinksByMediaIDs(ctx context.Context, mediaIDs []string) (map[string]string, error) {
+	const batchSize = 25
+
+	relativeURLs := make([]string, len(mediaIDs))
+	for i, mediaID := range mediaIDs {
+		requestURL := url.URL{Path: mediaID}
+		query := requestURL.Query()
+		query.Set("fields", "permalink")
+		requestURL.RawQuery = query.Encode()
+		relativeURLs[i] = requestURL.String()
+	}
+	batchResponses, err := ps.getBatches(ctx, relativeURLs, batchSize, 4)
+	if err != nil {
+		return nil, err
+	}
+
+	result := make(map[string]string, len(mediaIDs))
+	for i, batchResponse := range batchResponses {
+		post := struct {
+			Permalink string `json:"permalink"`
+		}{}
+		if err := decodeGraphBatchResponse(batchResponse, &post); err != nil {
+			return nil, err
+		}
+		result[mediaIDs[i]] = post.Permalink
+	}
+	return result, nil
+}
+
 type InstagramComment struct {
 	ID        string  `json:"id,omitempty"`
 	Text      string  `json:"text,omitempty"`
@@ -130,31 +159,26 @@ func (ps *PostService) ListInstagramCommentsByMediaIDs(ctx context.Context, medi
 		result[mediaID] = []InstagramComment{}
 	}
 
-	for start := 0; start < len(mediaIDs); start += batchSize {
-		end := start + batchSize
-		if end > len(mediaIDs) {
-			end = len(mediaIDs)
-		}
-
-		route := fb.NewRoute(Version, "/").
-			Fields("comments.limit(1000){id,text,replies.limit(1000){id,text}}")
-		requestURL, err := url.Parse(route.String())
-		if err != nil {
-			return nil, err
-		}
+	relativeURLs := make([]string, len(mediaIDs))
+	for i, mediaID := range mediaIDs {
+		requestURL := url.URL{Path: mediaID}
 		query := requestURL.Query()
-		query.Set("ids", strings.Join(mediaIDs[start:end], ","))
+		query.Set("fields", "comments.limit(1000){id,text,replies.limit(1000){id,text}}")
 		requestURL.RawQuery = query.Encode()
-
-		posts := map[string]struct {
+		relativeURLs[i] = requestURL.String()
+	}
+	batchResponses, err := ps.getBatches(ctx, relativeURLs, batchSize, 4)
+	if err != nil {
+		return nil, err
+	}
+	for i, batchResponse := range batchResponses {
+		post := struct {
 			Comments instagramComments `json:"comments"`
 		}{}
-		if err := ps.c.GetJSON(ctx, requestURL.String(), &posts); err != nil {
+		if err := decodeGraphBatchResponse(batchResponse, &post); err != nil {
 			return nil, err
 		}
-		for mediaID, post := range posts {
-			result[mediaID] = post.Comments.flatten()
-		}
+		result[mediaIDs[i]] = post.Comments.flatten()
 	}
 
 	return result, nil

--- a/marketing/v24/instagram_post_test.go
+++ b/marketing/v24/instagram_post_test.go
@@ -2,16 +2,85 @@ package v24
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"reflect"
 	"strings"
+	"sync/atomic"
 	"testing"
 
 	"github.com/go-kit/log"
 	"github.com/justwatch/facebook-marketing-api-golang-sdk/fb"
 )
+
+func TestGetInstagramPermalinksByMediaIDs(t *testing.T) {
+	mediaIDs := make([]string, 26)
+	for i := range mediaIDs {
+		mediaIDs[i] = fmt.Sprintf("media-%d", i)
+	}
+
+	var requests atomic.Int32
+	client := fb.NewClient(log.NewNopLogger(), "token", "")
+	client.Client = &http.Client{Transport: instagramCommentsRoundTripFunc(func(request *http.Request) (*http.Response, error) {
+		requests.Add(1)
+		requestBody, err := io.ReadAll(request.Body)
+		if err != nil {
+			t.Fatalf("read batch request: %v", err)
+		}
+		form, err := url.ParseQuery(string(requestBody))
+		if err != nil {
+			t.Fatalf("parse batch form: %v", err)
+		}
+		batch := []graphBatchRequest{}
+		if err := json.Unmarshal([]byte(form.Get("batch")), &batch); err != nil {
+			t.Fatalf("parse batch requests: %v", err)
+		}
+
+		batchResponses := make([]graphBatchResponse, len(batch))
+		for i, batchRequest := range batch {
+			requestURL, err := url.Parse(batchRequest.RelativeURL)
+			if err != nil {
+				t.Fatalf("parse relative URL: %v", err)
+			}
+			if got, want := requestURL.Query().Get("fields"), "permalink"; got != want {
+				t.Fatalf("fields = %q, want %q", got, want)
+			}
+			body, err := json.Marshal(struct {
+				Permalink string `json:"permalink"`
+			}{Permalink: "https://instagram.com/p/" + requestURL.Path})
+			if err != nil {
+				t.Fatalf("marshal permalink response: %v", err)
+			}
+			batchResponses[i] = graphBatchResponse{Code: http.StatusOK, Body: string(body)}
+		}
+		responseBody, err := json.Marshal(batchResponses)
+		if err != nil {
+			t.Fatalf("marshal batch responses: %v", err)
+		}
+
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Status:     "200 OK",
+			Body:       io.NopCloser(strings.NewReader(string(responseBody))),
+			Request:    request,
+		}, nil
+	})}
+	service := &PostService{c: client}
+
+	got, err := service.GetInstagramPermalinksByMediaIDs(context.Background(), mediaIDs)
+	if err != nil {
+		t.Fatalf("GetInstagramPermalinksByMediaIDs() error = %v", err)
+	}
+	if requests.Load() != 2 {
+		t.Fatalf("requests = %d, want 2", requests.Load())
+	}
+	if permalink := got["media-25"]; permalink != "https://instagram.com/p/media-25" {
+		t.Fatalf("permalink for media-25 = %q", permalink)
+	}
+}
 
 func TestListInstagramCommentsByMediaIDs(t *testing.T) {
 	mediaIDs := make([]string, 26)
@@ -19,22 +88,48 @@ func TestListInstagramCommentsByMediaIDs(t *testing.T) {
 		mediaIDs[i] = fmt.Sprintf("media-%d", i)
 	}
 
-	requests := 0
+	var requests atomic.Int32
 	client := fb.NewClient(log.NewNopLogger(), "token", "")
 	client.Client = &http.Client{Transport: instagramCommentsRoundTripFunc(func(request *http.Request) (*http.Response, error) {
-		requests++
+		requests.Add(1)
 		if request.URL.Path != "/v24.0/" {
 			t.Fatalf("request path = %q, want %q", request.URL.Path, "/v24.0/")
 		}
-		if got, want := request.URL.Query().Get("fields"), "comments.limit(1000){id,text,replies.limit(1000){id,text}}"; got != want {
-			t.Fatalf("fields = %q, want %q", got, want)
+		if request.Method != http.MethodPost {
+			t.Fatalf("request method = %q, want %q", request.Method, http.MethodPost)
 		}
 
-		var body string
-		switch request.URL.Query().Get("ids") {
-		case strings.Join(mediaIDs[:25], ","):
-			body = `{
-				"media-0": {
+		requestBody, err := io.ReadAll(request.Body)
+		if err != nil {
+			t.Fatalf("read batch request: %v", err)
+		}
+		form, err := url.ParseQuery(string(requestBody))
+		if err != nil {
+			t.Fatalf("parse batch form: %v", err)
+		}
+		batch := []graphBatchRequest{}
+		if err := json.Unmarshal([]byte(form.Get("batch")), &batch); err != nil {
+			t.Fatalf("parse batch requests: %v", err)
+		}
+
+		if len(batch) == 0 || len(batch) > 25 {
+			t.Fatalf("batch size = %d, want 1 through 25", len(batch))
+		}
+
+		batchResponses := make([]graphBatchResponse, len(batch))
+		for i, batchRequest := range batch {
+			requestURL, err := url.Parse(batchRequest.RelativeURL)
+			if err != nil {
+				t.Fatalf("parse relative URL: %v", err)
+			}
+			if got, want := requestURL.Query().Get("fields"), "comments.limit(1000){id,text,replies.limit(1000){id,text}}"; got != want {
+				t.Fatalf("fields = %q, want %q", got, want)
+			}
+
+			batchResponses[i] = graphBatchResponse{Code: http.StatusOK, Body: `{}`}
+			switch requestURL.Path {
+			case "media-0":
+				batchResponses[i].Body = `{
 					"comments": {
 						"data": [{
 							"id": "comment-1",
@@ -44,24 +139,24 @@ func TestListInstagramCommentsByMediaIDs(t *testing.T) {
 							}
 						}]
 					}
-				}
-			}`
-		case mediaIDs[25]:
-			body = `{
-				"media-25": {
+				}`
+			case "media-25":
+				batchResponses[i].Body = `{
 					"comments": {
 						"data": [{"id": "comment-2", "text": "second"}]
 					}
-				}
-			}`
-		default:
-			t.Fatalf("unexpected ids query: %q", request.URL.Query().Get("ids"))
+				}`
+			}
+		}
+		responseBody, err := json.Marshal(batchResponses)
+		if err != nil {
+			t.Fatalf("marshal batch responses: %v", err)
 		}
 
 		return &http.Response{
 			StatusCode: http.StatusOK,
 			Status:     "200 OK",
-			Body:       io.NopCloser(strings.NewReader(body)),
+			Body:       io.NopCloser(strings.NewReader(string(responseBody))),
 			Request:    request,
 		}, nil
 	})}
@@ -71,8 +166,8 @@ func TestListInstagramCommentsByMediaIDs(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ListInstagramCommentsByMediaIDs() error = %v", err)
 	}
-	if requests != 2 {
-		t.Fatalf("requests = %d, want 2", requests)
+	if requests.Load() != 2 {
+		t.Fatalf("requests = %d, want 2", requests.Load())
 	}
 
 	wantFirst := []InstagramComment{

--- a/marketing/v24/post.go
+++ b/marketing/v24/post.go
@@ -166,81 +166,106 @@ func (ps *PostService) CountComments(ctx context.Context, postID string) (uint64
 // CountCommentsByPostIDs returns comment counts keyed by post ID.
 // Attached objects are resolved when the post itself reports no comments.
 func (ps *PostService) CountCommentsByPostIDs(ctx context.Context, postIDs []string) (map[string]uint64, error) {
-	const batchSize = 50
-
-	counts := make(map[string]uint64, len(postIDs))
-	postIDsByObjectID := map[string][]string{}
-
-	for start := 0; start < len(postIDs); start += batchSize {
-		end := start + batchSize
-		if end > len(postIDs) {
-			end = len(postIDs)
-		}
-
-		posts, err := ps.fetchPostCommentSummaries(ctx, postIDs[start:end])
-		if err != nil {
-			return nil, err
-		}
-		for postID, post := range posts {
-			if post.Comments.Summary.TotalCount > 0 || post.ObjectID == "" {
-				counts[postID] = post.Comments.Summary.TotalCount
-				continue
-			}
-			postIDsByObjectID[post.ObjectID] = append(postIDsByObjectID[post.ObjectID], postID)
+	counts, err := ps.fetchPostCommentCounts(ctx, postIDs)
+	if err != nil {
+		return nil, err
+	}
+	postIDsWithoutComments := make([]string, 0, len(postIDs))
+	for _, postID := range postIDs {
+		if counts[postID] == 0 {
+			postIDsWithoutComments = append(postIDsWithoutComments, postID)
 		}
 	}
 
-	objectIDs := make([]string, 0, len(postIDsByObjectID))
-	for objectID := range postIDsByObjectID {
-		objectIDs = append(objectIDs, objectID)
+	sort.Strings(postIDsWithoutComments)
+	objectIDsByPostID, err := ps.fetchPostAttachedObjectIDs(ctx, postIDsWithoutComments)
+	if err != nil {
+		return nil, err
+	}
+
+	postIDsByObjectID := make(map[string][]string, len(objectIDsByPostID))
+	objectIDs := make([]string, 0, len(objectIDsByPostID))
+	for postID, objectID := range objectIDsByPostID {
+		if len(postIDsByObjectID[objectID]) == 0 {
+			objectIDs = append(objectIDs, objectID)
+		}
+		postIDsByObjectID[objectID] = append(postIDsByObjectID[objectID], postID)
 	}
 	sort.Strings(objectIDs)
 
-	for start := 0; start < len(objectIDs); start += batchSize {
-		end := start + batchSize
-		if end > len(objectIDs) {
-			end = len(objectIDs)
-		}
-
-		objects, err := ps.fetchPostCommentSummaries(ctx, objectIDs[start:end])
-		if err != nil {
-			return nil, err
-		}
-		for objectID, object := range objects {
-			for _, postID := range postIDsByObjectID[objectID] {
-				counts[postID] = object.Comments.Summary.TotalCount
-			}
+	objectCounts, err := ps.fetchPostCommentCounts(ctx, objectIDs)
+	if err != nil {
+		return nil, err
+	}
+	for objectID, objectCount := range objectCounts {
+		for _, postID := range postIDsByObjectID[objectID] {
+			counts[postID] = objectCount
 		}
 	}
 
 	return counts, nil
 }
 
-type postCommentSummary struct {
-	ObjectID string `json:"object_id"`
-	Comments struct {
-		Summary struct {
-			TotalCount uint64 `json:"total_count"`
-		} `json:"summary"`
-	} `json:"comments"`
+type postAttachments struct {
+	Data []struct {
+		Target struct {
+			ID string `json:"id"`
+		} `json:"target"`
+	} `json:"data"`
 }
 
-func (ps *PostService) fetchPostCommentSummaries(ctx context.Context, postIDs []string) (map[string]postCommentSummary, error) {
-	route := fb.NewRoute(Version, "/").
-		Fields("object_id", "comments.limit(0).summary(true)")
-	requestURL, err := url.Parse(route.String())
+func (ps *PostService) fetchPostCommentCounts(ctx context.Context, postIDs []string) (map[string]uint64, error) {
+	relativeURLs := make([]string, len(postIDs))
+	for i, postID := range postIDs {
+		requestURL := url.URL{Path: postID + "/comments"}
+		query := requestURL.Query()
+		query.Set("limit", "0")
+		query.Set("summary", "true")
+		requestURL.RawQuery = query.Encode()
+		relativeURLs[i] = requestURL.String()
+	}
+
+	batchResponses, err := ps.getBatches(ctx, relativeURLs, 10, 4)
 	if err != nil {
 		return nil, err
 	}
-	query := requestURL.Query()
-	query.Set("ids", strings.Join(postIDs, ","))
-	requestURL.RawQuery = query.Encode()
 
-	posts := map[string]postCommentSummary{}
-	if err := ps.c.GetJSON(ctx, requestURL.String(), &posts); err != nil {
+	counts := make(map[string]uint64, len(postIDs))
+	for i, batchResponse := range batchResponses {
+		summary := fb.SummaryContainer{}
+		if err := decodeGraphBatchResponse(batchResponse, &summary); err != nil {
+			return nil, err
+		}
+		counts[postIDs[i]] = summary.Summary.TotalCount
+	}
+	return counts, nil
+}
+
+func (ps *PostService) fetchPostAttachedObjectIDs(ctx context.Context, postIDs []string) (map[string]string, error) {
+	relativeURLs := make([]string, len(postIDs))
+	for i, postID := range postIDs {
+		relativeURLs[i] = postID + "/attachments?fields=target"
+	}
+
+	batchResponses, err := ps.getBatches(ctx, relativeURLs, 10, 4)
+	if err != nil {
 		return nil, err
 	}
-	return posts, nil
+
+	objectIDsByPostID := make(map[string]string, len(postIDs))
+	for i, batchResponse := range batchResponses {
+		attachments := postAttachments{}
+		if err := decodeGraphBatchResponse(batchResponse, &attachments); err != nil {
+			if fb.IsNotFound(err) {
+				continue
+			}
+			return nil, err
+		}
+		if len(attachments.Data) > 0 && attachments.Data[0].Target.ID != "" {
+			objectIDsByPostID[postIDs[i]] = attachments.Data[0].Target.ID
+		}
+	}
+	return objectIDsByPostID, nil
 }
 
 // ListComments creates a new CommentListCall

--- a/marketing/v24/post_comments_test.go
+++ b/marketing/v24/post_comments_test.go
@@ -2,10 +2,13 @@ package v24
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"strings"
+	"sync/atomic"
 	"testing"
 
 	"github.com/go-kit/log"
@@ -13,58 +16,87 @@ import (
 )
 
 func TestCountCommentsByPostIDsBatchesAndResolvesAttachedObjects(t *testing.T) {
-	postIDs := make([]string, 51)
+	postIDs := make([]string, 11)
 	for i := range postIDs {
 		postIDs[i] = fmt.Sprintf("post-%d", i)
 	}
 	postIDs[0] = "page_shell"
 
-	requests := 0
+	var requests atomic.Int32
 	client := fb.NewClient(log.NewNopLogger(), "token", "")
 	client.Client = &http.Client{Transport: postCommentsRoundTripFunc(func(request *http.Request) (*http.Response, error) {
-		requests++
+		requests.Add(1)
 		if request.URL.Path != "/v24.0/" {
 			t.Fatalf("request path = %q, want %q", request.URL.Path, "/v24.0/")
 		}
-		if got, want := request.URL.Query().Get("fields"), "object_id,comments.limit(0).summary(true)"; got != want {
-			t.Fatalf("fields = %q, want %q", got, want)
+		if request.Method != http.MethodPost {
+			t.Fatalf("request method = %q, want %q", request.Method, http.MethodPost)
 		}
 
-		var body string
-		switch request.URL.Query().Get("ids") {
-		case strings.Join(postIDs[:50], ","):
-			body = `{
-				"page_shell": {
-					"object_id": "reel",
-					"comments": {"summary": {"total_count": 0}}
-				},
-				"post-1": {
-					"comments": {"summary": {"total_count": 2}}
-				},
-				"post-2": {
-					"comments": {"summary": {"total_count": 0}}
+		requestBody, err := io.ReadAll(request.Body)
+		if err != nil {
+			t.Fatalf("read batch request: %v", err)
+		}
+		form, err := url.ParseQuery(string(requestBody))
+		if err != nil {
+			t.Fatalf("parse batch form: %v", err)
+		}
+		batch := []graphBatchRequest{}
+		if err := json.Unmarshal([]byte(form.Get("batch")), &batch); err != nil {
+			t.Fatalf("parse batch requests: %v", err)
+		}
+		if len(batch) == 0 || len(batch) > 10 {
+			t.Fatalf("batch size = %d, want 1 through 10", len(batch))
+		}
+
+		batchResponses := make([]graphBatchResponse, len(batch))
+		for i, batchRequest := range batch {
+			requestURL, err := url.Parse(batchRequest.RelativeURL)
+			if err != nil {
+				t.Fatalf("parse relative URL: %v", err)
+			}
+
+			batchResponses[i] = graphBatchResponse{Code: http.StatusOK}
+			switch {
+			case strings.HasSuffix(requestURL.Path, "/comments"):
+				if requestURL.Query().Get("limit") != "0" || requestURL.Query().Get("summary") != "true" {
+					t.Fatalf("unexpected comments query: %q", requestURL.RawQuery)
 				}
-			}`
-		case postIDs[50]:
-			body = `{
-				"post-50": {
-					"comments": {"summary": {"total_count": 4}}
+				postID := strings.TrimSuffix(requestURL.Path, "/comments")
+				count := uint64(1)
+				switch postID {
+				case "page_shell", "post-2":
+					count = 0
+				case "post-1":
+					count = 2
+				case "post-10":
+					count = 4
+				case "reel":
+					count = 3
 				}
-			}`
-		case "reel":
-			body = `{
-				"reel": {
-					"comments": {"summary": {"total_count": 3}}
+				batchResponses[i].Body = fmt.Sprintf(`{"summary":{"total_count":%d}}`, count)
+			case strings.HasSuffix(requestURL.Path, "/attachments"):
+				if got, want := requestURL.Query().Get("fields"), "target"; got != want {
+					t.Fatalf("attachment fields = %q, want %q", got, want)
 				}
-			}`
-		default:
-			t.Fatalf("unexpected ids query: %q", request.URL.Query().Get("ids"))
+				postID := strings.TrimSuffix(requestURL.Path, "/attachments")
+				batchResponses[i].Body = `{"data":[]}`
+				if postID == "page_shell" {
+					batchResponses[i].Body = `{"data":[{"target":{"id":"reel"}}]}`
+				}
+			default:
+				t.Fatalf("unexpected relative URL: %q", batchRequest.RelativeURL)
+			}
+		}
+		body, err := json.Marshal(batchResponses)
+		if err != nil {
+			t.Fatalf("marshal batch responses: %v", err)
 		}
 
 		return &http.Response{
 			StatusCode: http.StatusOK,
 			Status:     "200 OK",
-			Body:       io.NopCloser(strings.NewReader(body)),
+			Body:       io.NopCloser(strings.NewReader(string(body))),
 			Request:    request,
 		}, nil
 	})}
@@ -74,23 +106,23 @@ func TestCountCommentsByPostIDsBatchesAndResolvesAttachedObjects(t *testing.T) {
 	if err != nil {
 		t.Fatalf("CountCommentsByPostIDs() error = %v", err)
 	}
-	if requests != 3 {
-		t.Fatalf("requests = %d, want 3", requests)
+	if requests.Load() != 4 {
+		t.Fatalf("requests = %d, want 4", requests.Load())
 	}
 
 	want := map[string]uint64{
 		"page_shell": 3,
 		"post-1":     2,
 		"post-2":     0,
-		"post-50":    4,
+		"post-10":    4,
 	}
 	for postID, wantCount := range want {
 		if count, ok := got[postID]; !ok || count != wantCount {
 			t.Fatalf("count for %s = %d, %t; want %d, true", postID, count, ok, wantCount)
 		}
 	}
-	if _, ok := got["post-3"]; ok {
-		t.Fatal("missing API response for post-3 should not produce a count")
+	if count := got["post-3"]; count != 1 {
+		t.Fatalf("count for post-3 = %d, want 1", count)
 	}
 }
 


### PR DESCRIPTION
## Summary
- use Graph Batch API with dedicated comment and attachment edges
- batch Instagram comment and permalink lookups with bounded concurrency
- preserve attached-object comment fallback without deprecated fields

## Test plan
- [x] run focused v24 tests with the race detector
- [x] run jw-business-api Facebook and comments controller tests against the local SDK
- [x] verify `/comments/social-links/48679` locally (HTTP 200 in 44 seconds, no Graph warnings)
- [ ] full SDK suite (blocked by existing v22/v24 campaign effective-status test failures)